### PR TITLE
Add positioning info to month selector IconButton

### DIFF
--- a/src/MonthSelector.qml
+++ b/src/MonthSelector.qml
@@ -69,6 +69,11 @@ Item {
 
     IconButton {
         iconName: "ios-checkmark-circle-outline"
+        anchors {
+            bottom: parent.bottom
+            horizontalCenter: parent.horizontalCenter
+            bottomMargin: Dims.iconButtonMargin
+        }
         onClicked: {
             month = monthLV.currentIndex
             year = yearLV.currentIndex + 2000


### PR DESCRIPTION
The change to the IconButton described in AsteroidOS/qml-asteroid#26 means that uses of IconButton must explicitly specify positioning information.  This adds that information to position the button correctly at the bottom of the screen.

Signed-off-by: Ed Beroset <beroset@ieee.org>