### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ ecm_find_qmlmodule(org.nemomobile.calendar 1.0)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-calendar.in
+	${CMAKE_BINARY_DIR}/asteroid-calendar
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-calendar
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-calendar)
 

--- a/asteroid-calendar.desktop.template
+++ b/asteroid-calendar.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-calendar
+Exec=asteroid-calendar
 Icon=ios-calendar-outline
 X-Asteroid-Center-Color=#CC7700
 X-Asteroid-Outer-Color=#0C0300

--- a/asteroid-calendar.in
+++ b/asteroid-calendar.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-calendar.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-calendar main.cpp resources.qrc)
-set_target_properties(asteroid-calendar PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-calendar PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-calendar PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-calendar
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker