### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/EventDialog.qml
+++ b/src/EventDialog.qml
@@ -54,13 +54,13 @@ Item {
 
         anchors {
             left: parent.left
-            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(10) : 0
+            leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(10) : 0
             right: parent.right
-            rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(10) : 0
+            rightMargin: DeviceSpecs.hasRoundScreen ? Dims.w(10) : 0
             top: title.bottom
         }
         height: Dims.h(38)
-        width: DeviceInfo.hasRoundScreen ? Dims.w(80) : Dims.w(100)
+        width: DeviceSpecs.hasRoundScreen ? Dims.w(80) : Dims.w(100)
 
         property int spinnerWidth: use12H.value ? timeSelector.width / 3 : timeSelector.width / 2
 

--- a/src/MonthSelector.qml
+++ b/src/MonthSelector.qml
@@ -35,9 +35,9 @@ Item {
 
         anchors {
             left: parent.left
-            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(10) : 0
+            leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(10) : 0
             right: parent.right
-            rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(10) : 0
+            rightMargin: DeviceSpecs.hasRoundScreen ? Dims.w(10) : 0
             top: title.bottom
         }
         height: Dims.h(60)

--- a/src/main.qml
+++ b/src/main.qml
@@ -75,7 +75,7 @@ Application {
             onDaySelectorHeightChanged: agenda.contentY = -daySelectorHeight
 
             function animateToDayView() {
-                yAnimation.to = DeviceInfo.hasRoundScreen ? -dayInfoHeight : 0
+                yAnimation.to = DeviceSpecs.hasRoundScreen ? -dayInfoHeight : 0
                 yAnimation.start()
             }
 
@@ -109,7 +109,7 @@ Application {
                 delegate: MouseArea {
                     height: agenda.contentY > -daySelectorHeight / 2 ?
                                 dayInfoHeight * 1.186 :
-                                DeviceInfo.hasRoundScreen ?
+                                DeviceSpecs.hasRoundScreen ?
                                     dayInfoHeight * .94 :
                                     dayInfoHeight
                     width: parent.width
@@ -216,7 +216,7 @@ Application {
                 }
 
                 header: Item { height: daySelectorHeight }
-                footer: Item { height: Math.max(2 * dayInfoHeight, agenda.height - agenda.count * dayInfoHeight * 1.186) - (DeviceInfo.hasRoundScreen ? dayInfoHeight / 2 : 0) }
+                footer: Item { height: Math.max(2 * dayInfoHeight, agenda.height - agenda.count * dayInfoHeight * 1.186) - (DeviceSpecs.hasRoundScreen ? dayInfoHeight / 2 : 0) }
             }
 
             Rectangle {
@@ -513,7 +513,7 @@ Application {
                         else return dayInfoHeight - daySelector.height
                     }
                 }
-                Component.onCompleted: if(!DeviceInfo.hasRoundScreen) anchors.topMargin = 0
+                Component.onCompleted: if(!DeviceSpecs.hasRoundScreen) anchors.topMargin = 0
                 height: dayInfoHeight
                 color: overlayColor
 


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes https://github.com/AsteroidOS/qml-asteroid/issues/56