### PR TITLE
Build-time QML pre-compilation via asteroid_app_qml_module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_library(asteroid-calendar main.cpp resources.qrc)
 set_target_properties(asteroid-calendar PROPERTIES PREFIX "")
 
+asteroid_app_qml_module(asteroid-calendar
+	main.qml
+	EventDialog.qml
+	MonthSelector.qml
+)
+
 target_link_libraries(
 	asteroid-calendar
 	PUBLIC

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,8 +1,5 @@
 <RCC>
-    <qresource prefix="/">
-        <file>main.qml</file>
-        <file>EventDialog.qml</file>
-        <file>MonthSelector.qml</file>
+    <qresource prefix="/Calendar/">
         <file>day-background.svg</file>
         <file>day-background-leftstop.svg</file>
         <file>day-background-rightstop.svg</file>


### PR DESCRIPTION
The .so ships pre-compiled QML bytecode and the engine skips the parse/JIT pipeline on every launch.