### PR TITLE
Fix Qt6 initial property injection for EventDialog

### DIFF
--- a/src/EventDialog.qml
+++ b/src/EventDialog.qml
@@ -24,6 +24,7 @@ import org.asteroid.utils
 
 Item {
     id: root
+    property int depth
     property var pop
     property var event
 


### PR DESCRIPTION
Qt6 only allows passing initial properties via push() if they are explicitly declared on the target component. The EventDialog page was missing property int depth, causing Setting initial properties failed errors every time it opens.

It's a similar change to
https://github.com/AsteroidOS/asteroid-settings/commit/5e4e38857b8635a74cef32b7f2f017240ea3162a