### PR TITLE
Use org.asteroid.utils WallClock instead of Nemo.Time

### DIFF
--- a/src/EventDialog.qml
+++ b/src/EventDialog.qml
@@ -16,7 +16,6 @@
  */
 
 import QtQuick
-import Nemo.Time
 import Nemo.Configuration
 import org.nemomobile.calendar
 import org.asteroid.controls


### PR DESCRIPTION
WallClock is now provided by qml-asteroid's org.asteroid.utils module, so drop the dependency on the Nemo.Time QML plugin.